### PR TITLE
v0.2.3

### DIFF
--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -1,0 +1,26 @@
+name: pypi
+
+on:
+  release:
+    types: [created]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python
+      uses: actions/setup-python@v1
+      with:
+        python-version: '3.x'
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install setuptools wheel twine
+    - name: Build and publish
+      env:
+        TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
+        TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
+      run: |
+        python setup.py sdist bdist_wheel
+        twine upload dist/*

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # opax
 
-`opax` is an optimizer library for Jax. It is a reimplementation of [optax] using `Pax`'s stateful [module](https://github.com/ntt123/pax).
+`opax` is an optimizer library for JAX. It is a reimplementation of [optax] using PAX's stateful [module](https://github.com/ntt123/pax).
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ To update parameters:
 
 ```python
 updates, optimizer = opax.transfrom_gradients(gradients, optimizer, parameters)
-parameters = opax.apply_update(parameters, updates)
+parameters = opax.apply_updates(parameters, updates)
 ```
 
 **Note**: ``gradients`` has the same `treedef` as `parameters`.

--- a/README.md
+++ b/README.md
@@ -24,7 +24,8 @@ optimizer = opax.adam(1e-4)(parameters)
 To update parameters:
 
 ```python
-new_parameters = optimizer.step(gradients, parameters)
+updates, optimizer = opax.transfrom_gradients(gradients, optimizer, parameters)
+parameters = opax.apply_update(parameters, updates)
 ```
 
 **Note**: ``gradients`` has the same `treedef` as `parameters`.

--- a/examples/mnist.py
+++ b/examples/mnist.py
@@ -4,18 +4,13 @@ from typing import List, Mapping, Tuple
 
 import jax
 import jax.numpy as jnp
-import opax
 import pax
 import tensorflow_datasets as tfds
 from tqdm.auto import tqdm
 
-Batch = Mapping[str, jnp.ndarray]
+import opax
 
-# config
-batch_size = 32
-num_epochs = 5
-learning_rate = 1e-4
-weight_decay = 1e-4
+Batch = Mapping[str, jnp.ndarray]
 
 
 class ConvNet(pax.Module):
@@ -29,18 +24,19 @@ class ConvNet(pax.Module):
         self.layers = []
         for i in range(5):
             conv = pax.nn.Conv2D((1 if i == 0 else 32), 32, 6, padding="VALID")
-            bn = pax.nn.BatchNorm2D(32, True, True, 0.9)
-            self.layers.append((conv, bn))
+            batchnorm = pax.nn.BatchNorm2D(32, True, True, 0.9)
+            self.layers.append((conv, batchnorm))
         self.output = pax.nn.Conv2D(32, 10, 3, padding="VALID")
 
     def __call__(self, x: jnp.ndarray):
-        for conv, bn in self.layers:
-            x = bn(conv(x))
+        for conv, batchnorm in self.layers:
+            x = batchnorm(conv(x))
             x = jax.nn.relu(x)
         x = self.output(x)
         return jnp.squeeze(x, (1, 2))
 
 
+@pax.pure
 def loss_fn(model: ConvNet, batch: Batch):
     x = batch["image"].astype(jnp.float32) / 255
     target = batch["label"]
@@ -61,46 +57,55 @@ def test_loss_fn(model: ConvNet, batch: Batch):
 def update_fn(model: ConvNet, optimizer: opax.GradientTransformation, batch: Batch):
     grads, (loss, model) = jax.grad(loss_fn, has_aux=True, allow_int=int)(model, batch)
     params = model.parameters()
-    updates = optimizer(grads.parameters(), params=params)
-    new_params = pax.apply_updates(params, updates=updates)
+    updates, optimizer = opax.transform_gradients(grads, optimizer, params=params)
+    new_params = opax.apply_updates(params, updates=updates)
     model = model.update_parameters(new_params)
     return model, optimizer, loss
 
 
-net = ConvNet()
-print(net.summary())
-optimizer = opax.chain(
-    opax.clip_by_global_norm(1.0),
-    opax.adam(learning_rate=learning_rate),
-)(net.parameters())
-
-
 def load_dataset(split: str):
     """Loads the dataset as a tensorflow dataset."""
-    ds = tfds.load("mnist:3.*.*", split=split)
-    return ds
+    dataset = tfds.load("mnist:3.*.*", split=split)
+    return dataset
 
 
-train_data = load_dataset("train").shuffle(10 * batch_size).batch(batch_size)
-test_data = load_dataset("test").shuffle(10 * batch_size).batch(batch_size)
+def train(
+    batch_size=32,
+    num_epochs=10,
+    learning_rate=1e-4,
+    weight_decay=1e-4,
+):
+    net = ConvNet()
+    print(net.summary())
+    optimizer = opax.chain(
+        opax.clip_by_global_norm(1.0),
+        opax.adamw(learning_rate=learning_rate, weight_decay=weight_decay),
+    )(net.parameters())
+
+    train_data = load_dataset("train").shuffle(10 * batch_size).batch(batch_size)
+    test_data = load_dataset("test").shuffle(10 * batch_size).batch(batch_size)
+
+    for epoch in range(num_epochs):
+        losses, global_norm = 0.0, 0.0
+        for batch in tqdm(train_data, desc="train", leave=False):
+            batch = jax.tree_map(lambda x: x.numpy(), batch)
+            net, optimizer, loss = update_fn(net, optimizer, batch)
+            losses = losses + loss
+            global_norm = global_norm + optimizer[0].global_norm
+        loss = losses / len(train_data)
+        global_norm = global_norm / len(train_data)
+
+        test_losses = 0.0
+        for batch in tqdm(test_data, desc="eval", leave=False):
+            batch = jax.tree_map(lambda x: x.numpy(), batch)
+            test_losses = test_losses + test_loss_fn(net, batch)
+        test_loss = test_losses / len(test_data)
+
+        print(
+            f"[Epoch {epoch}]  train loss {loss:.3f}  test loss {test_loss:.3f}  global norm {global_norm:.3f}"
+        )
+
+    return net
 
 
-for epoch in range(0, 10):
-    losses, global_norm = 0.0, 0.0
-    for batch in tqdm(train_data, desc="train", leave=False):
-        batch = jax.tree_map(lambda x: x.numpy(), batch)
-        net, optimizer, loss = update_fn(net, optimizer, batch)
-        losses = losses + loss
-        global_norm = global_norm + optimizer[0].global_norm
-    loss = losses / len(train_data)
-    global_norm = global_norm / len(train_data)
-
-    test_losses = 0.0
-    for batch in tqdm(test_data, desc="eval", leave=False):
-        batch = jax.tree_map(lambda x: x.numpy(), batch)
-        test_losses = test_losses + test_loss_fn(net, batch)
-    test_loss = test_losses / len(test_data)
-
-    print(
-        f"[Epoch {epoch}]  train loss {loss:.3f}  test loss {test_loss:.3f}  global norm {global_norm:.3f}"
-    )
+train()

--- a/examples/mnist.py
+++ b/examples/mnist.py
@@ -26,12 +26,11 @@ class ConvNet(pax.Module):
 
     def __init__(self):
         super().__init__()
-        layers = []
+        self.layers = []
         for i in range(5):
             conv = pax.nn.Conv2D((1 if i == 0 else 32), 32, 6, padding="VALID")
             bn = pax.nn.BatchNorm2D(32, True, True, 0.9)
-            layers.append((conv, bn))
-        self.register_modules("layers", layers)
+            self.layers.append((conv, bn))
         self.output = pax.nn.Conv2D(32, 10, 3, padding="VALID")
 
     def __call__(self, x: jnp.ndarray):
@@ -42,8 +41,7 @@ class ConvNet(pax.Module):
         return jnp.squeeze(x, (1, 2))
 
 
-def loss_fn(params: ConvNet, model: ConvNet, batch: Batch):
-    model = model.update(params)
+def loss_fn(model: ConvNet, batch: Batch):
     x = batch["image"].astype(jnp.float32) / 255
     target = batch["label"]
     logits = model(x)
@@ -56,17 +54,17 @@ def loss_fn(params: ConvNet, model: ConvNet, batch: Batch):
 @jax.jit
 def test_loss_fn(model: ConvNet, batch: Batch):
     model = model.eval()
-    return loss_fn(model.parameters(), model, batch)[0]
+    return loss_fn(model, batch)[0]
 
 
 @jax.jit
 def update_fn(model: ConvNet, optimizer: opax.GradientTransformation, batch: Batch):
+    grads, (loss, model) = jax.grad(loss_fn, has_aux=True, allow_int=int)(model, batch)
     params = model.parameters()
-    grads, (loss, model) = jax.grad(loss_fn, has_aux=True)(params, model, batch)
-    model = model.update(
-        optimizer.step(grads, model.parameters()),
-    )
-    return loss, model, optimizer
+    updates = optimizer(grads.parameters(), params=params)
+    new_params = pax.apply_updates(params, updates=updates)
+    model = model.update_parameters(new_params)
+    return model, optimizer, loss
 
 
 net = ConvNet()
@@ -91,7 +89,7 @@ for epoch in range(0, 10):
     losses, global_norm = 0.0, 0.0
     for batch in tqdm(train_data, desc="train", leave=False):
         batch = jax.tree_map(lambda x: x.numpy(), batch)
-        loss, net, optimizer = update_fn(net, optimizer, batch)
+        net, optimizer, loss = update_fn(net, optimizer, batch)
         losses = losses + loss
         global_norm = global_norm + optimizer[0].global_norm
     loss = losses / len(train_data)

--- a/opax/__init__.py
+++ b/opax/__init__.py
@@ -1,4 +1,4 @@
-"""Pax optimizer library."""
+"""PAX optimizer library."""
 
 from . import optimizer, schedule
 from .optimizer import adam, adamw, rmsprop, sgd

--- a/opax/__init__.py
+++ b/opax/__init__.py
@@ -14,3 +14,4 @@ from .transform import (
     scale_by_stddev,
     trace,
 )
+from .utils import apply_updates

--- a/opax/__init__.py
+++ b/opax/__init__.py
@@ -15,3 +15,5 @@ from .transform import (
     trace,
 )
 from .utils import apply_gradients, apply_updates, transform_gradients
+
+__version__ = "0.2.3"

--- a/opax/__init__.py
+++ b/opax/__init__.py
@@ -14,4 +14,4 @@ from .transform import (
     scale_by_stddev,
     trace,
 )
-from .utils import apply_updates
+from .utils import apply_gradients, apply_updates, transform_gradients

--- a/opax/schedule.py
+++ b/opax/schedule.py
@@ -4,8 +4,6 @@ from typing import Callable, Optional, Union
 import jax.numpy as jnp
 
 ScheduleFn = Callable[[jnp.ndarray], jnp.ndarray]
-
-
 ScheduleOrFloat = Union[Callable, float]
 
 

--- a/opax/transform.py
+++ b/opax/transform.py
@@ -1,12 +1,10 @@
 """Gradient Transformations."""
 
-from typing import Any, Callable, Optional, Sequence, TypeVar
+from typing import Any, Callable, Sequence, TypeVar
 
 import jax
 import jax.numpy as jnp
 import pax
-
-from .utils import select_tree
 
 T = TypeVar("T")
 
@@ -17,40 +15,6 @@ class GradientTransformation(pax.Module):
 
     def __call__(self, updates, params=None):
         raise NotImplementedError("A subclass must implement this method")
-
-    def step(self, grads, params, all_finite: Optional[jnp.ndarray] = None):
-        """An optimizing step.
-
-        First, transform gradients
-        Second, apply updates to parameters.
-
-        If `all_finite` is False, no update is applied.
-
-        Arguments:
-            grads: The gradients.
-            params: The model parameters that will be updated.
-            all_finite: if the gradients are all finite. Default: `None`.
-        """
-        if jax.tree_structure(grads) != jax.tree_structure(params):
-            raise ValueError(
-                f"Mismatched between `grads` and `params` tree structures.\n"
-                f"Usually, this is due to a modification in the forward pass.\n\n"
-                f"[grads]\n{jax.tree_structure(grads)}\n\n"
-                f"========\n\n"
-                f"[params]\n{jax.tree_structure(params)}\n"
-            )
-        if all_finite is None:
-            updates = self(grads, params)
-            return jax.tree_map(lambda p, u: p - u, params, updates)
-        else:
-            clone = self.copy()
-            updates = self(grads, params)
-            new_params = jax.tree_map(lambda p, u: p - u, params, updates)
-            finite_params, finite_self = select_tree(
-                all_finite, (new_params, self), (params, clone)
-            )
-            self.update(finite_self, in_place=True)
-            return finite_params
 
 
 def identity():
@@ -78,8 +42,8 @@ def scale_by_schedule(schedule_fn: Callable[[jnp.ndarray], jnp.ndarray]):
         def __init__(self, params):
             super().__init__(params=params)
             self.schedule_fn = schedule_fn
-            self.register_states("count", jnp.array(0, dtype=jnp.int32))
-            self.register_states("learning_rate", jnp.array(0.0, dtype=jnp.float32))
+            self.register_state("count", jnp.array(0, dtype=jnp.int32))
+            self.register_state("learning_rate", jnp.array(0.0, dtype=jnp.float32))
 
         def __call__(self, updates, params=None):
             del params
@@ -100,7 +64,7 @@ def scale_by_stddev(
             super().__init__(params=params)
             self.register_states(
                 "mu",
-                jax.tree_map(jnp.zeros_likes, params),
+                jax.tree_map(jnp.zeros_like, params),
             )
             self.register_states(
                 "nu",
@@ -166,7 +130,7 @@ def clip_by_global_norm(max_global_norm: float):
 
         def __init__(self, params):
             super().__init__(params=params)
-            self.register_states("global_norm", jnp.array(0.0))
+            self.register_state("global_norm", jnp.array(0.0))
 
         def __call__(self, updates, params=None):
             del params
@@ -234,7 +198,7 @@ def ema(decay_rate: float, debias: bool = True):
 
         def __init__(self, params):
             super().__init__()
-            self.register_states("count", jnp.array(0, dtype=jnp.int32))
+            self.register_state("count", jnp.array(0, dtype=jnp.int32))
             self.register_states(
                 "ema", jax.tree_map(lambda x: jnp.zeros_like(x), params)
             )
@@ -270,7 +234,7 @@ def scale_by_adam(
             self.register_states(
                 "nu", jax.tree_map(lambda x: jnp.zeros_like(x), params)
             )
-            self.register_states("count", jnp.array(0, dtype=jnp.int32))
+            self.register_state("count", jnp.array(0, dtype=jnp.int32))
 
         def __call__(self, updates, params=None):
             del params
@@ -304,10 +268,9 @@ def chain(*fs: Callable[[Any], GradientTransformation]):
             self.flatten = flatten
             if flatten:
                 leaves = jax.tree_leaves(params)
-                transforms = [f(leaves) for f in fs]
+                self.transforms = [f(leaves) for f in fs]
             else:
-                transforms = [f(params) for f in fs]
-            self.register_modules("transforms", transforms)
+                self.transforms = [f(params) for f in fs]
 
         def __call__(self, updates, params=None):
             if self.flatten:

--- a/opax/utils.py
+++ b/opax/utils.py
@@ -70,8 +70,11 @@ def apply_gradients(
         - **new_optimizer**: the updated optimizer.
     """
     assert isinstance(model, Module), "Expecting a PAX Module."
+    assert type(model) is type(grads)
     params = model.parameters()
-    updates, new_optimizer = transform_gradients(grads, optimizer, params=params)
+    updates, new_optimizer = transform_gradients(
+        grads.parameters(), optimizer, params=params
+    )
     new_params = apply_updates(params, updates=updates)
 
     if all_finite is not None:

--- a/opax/utils.py
+++ b/opax/utils.py
@@ -5,11 +5,9 @@ import jax
 import jax.numpy as jnp
 
 T = TypeVar("T")
+U = TypeVar("U")
 
 
-# Source: https://github.com/deepmind/jmp/blob/fdfcb830de8331f90de289edb18355964ec1f9f9/jmp/_src/loss_scale.py#L187
-# This function is under the Apache License 2.0
-def select_tree(pred: jnp.ndarray, a: T, b: T) -> T:
-    """Selects a pytree based on the given predicate."""
-    assert pred.ndim == 0 and pred.dtype == jnp.bool_, "expected boolean scalar"
-    return jax.tree_multimap(functools.partial(jax.lax.select, pred), a, b)
+def apply_updates(params: T, updates: T) -> T:
+    """Return the updated parameters."""
+    return jax.tree_map(lambda p, u: p - u, params, updates)

--- a/opax/utils.py
+++ b/opax/utils.py
@@ -1,13 +1,83 @@
-import functools
-from typing import TypeVar
+"""Utility functions."""
+
+from typing import Any, Optional, Tuple, TypeVar
 
 import jax
 import jax.numpy as jnp
+import jmp
+
+from pax import Module, pure, assertStructureEqual
+from .transform import GradientTransformation
+
+TreeDef = Any
 
 T = TypeVar("T")
-U = TypeVar("U")
+K = TypeVar("K", bound=Module)
+O = TypeVar("O", bound=GradientTransformation)
+
+
+def transform_gradients(grads: T, optimizer: O, params: T) -> Tuple[T, O]:
+    """Transform gradients to updates using an optimizer.
+
+    Arguments:
+        grads: The gradients.
+        optimizer: The gradient transformation.
+        params: The trainable parameters.
+
+    Returns:
+        A pair ``(updates, optimizer)``
+
+        - **updates** : The transformed gradients.
+        - **optimizer** : The *updated* optimizer.
+    """
+
+    assert isinstance(optimizer, GradientTransformation), "Expecting an OPAX optimizer."
+
+    def _run(optimizer):
+        updates = optimizer(grads, params=params)
+        return optimizer, updates
+
+    optimizer, updates = pure(_run)(optimizer)
+    return updates, optimizer
 
 
 def apply_updates(params: T, updates: T) -> T:
-    """Return the updated parameters."""
-    return jax.tree_map(lambda p, u: p - u, params, updates)
+    """Update the parameters with updates.
+
+    Arguments:
+        params: The trainable parameters.
+        updates: The transformed gradients.
+    """
+    assertStructureEqual(updates, params)
+    return jax.tree_map(lambda u, p: p - u, updates, params)
+
+
+def apply_gradients(
+    model: T, optimizer: K, grads: T, all_finite: Optional[jnp.ndarray] = None
+) -> Tuple[T, K]:
+    """Update model and optimizer with gradients `grads`.
+
+    Arguments:
+        model: the model which contains trainable parameters.
+        optimizer: the gradient transformation.
+        grads: the gradients w.r.t to trainable parameters of `model`.
+        all_finite: True if gradients are finite. Default: `None`.
+
+    Returns:
+        A pair ``(new_model, new_optimizer)``
+
+        - **new_model**: the updated model.
+        - **new_optimizer**: the updated optimizer.
+    """
+    assert isinstance(model, Module), "Expecting a PAX Module."
+    params = model.parameters()
+    updates, new_optimizer = transform_gradients(grads, optimizer, params=params)
+    new_params = apply_updates(params, updates=updates)
+
+    if all_finite is not None:
+        new_params, new_optimizer = jmp.select_tree(
+            all_finite, (new_params, new_optimizer), (params, optimizer)
+        )
+
+    new_model = model.update_parameters(new_params)
+    return new_model, new_optimizer

--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,9 @@
 from setuptools import find_packages, setup
 
-__version__ = "0.2.1"
+__version__ = "0.2.2"
 url = "https://github.com/ntt123/opax"
 
-install_requires = ["pax3 >= 0.4.0rc1"]
+install_requires = ["pax3 >= 0.4.0rc2"]
 setup_requires = []
 tests_require = []
 

--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,21 @@
 from setuptools import find_packages, setup
 
-__version__ = "0.2.3rc1"
+
+def _get_version():
+    with open("opax/__init__.py", encoding="utf-8") as fp:
+        for line in fp:
+            if line.startswith("__version__"):
+                g = {}
+                exec(line, g)  # pylint: disable=exec-used
+                return g["__version__"]
+        raise ValueError("`__version__` not defined in `opax/__init__.py`")
+
+
+__version__ = _get_version()
+
 url = "https://github.com/ntt123/opax"
 
-install_requires = ["pax3 >= 0.4.0rc3"]
+install_requires = ["pax3>=0.4.0"]
 setup_requires = []
 tests_require = []
 
@@ -11,7 +23,7 @@ setup(
     name="opax",
     version=__version__,
     description="A stateful optimizer library for JAX",
-    long_description=open("README.md").read(),
+    long_description=open("README.md", encoding="utf-8").read(),
     long_description_content_type="text/markdown",
     author="Thông Nguyễn",
     url=url,

--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,9 @@
 from setuptools import find_packages, setup
 
-__version__ = "0.2.0"
+__version__ = "0.2.1"
 url = "https://github.com/ntt123/opax"
 
-install_requires = ["pax >= 0.3.0"]
+install_requires = ["pax >= 0.3.1"]
 setup_requires = []
 tests_require = []
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import find_packages, setup
 __version__ = "0.2.1"
 url = "https://github.com/ntt123/opax"
 
-install_requires = ["pax3 >= 0.3.1"]
+install_requires = ["pax3 >= 0.4.0rc1"]
 setup_requires = []
 tests_require = []
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import find_packages, setup
 __version__ = "0.2.1"
 url = "https://github.com/ntt123/opax"
 
-install_requires = ["pax >= 0.3.1"]
+install_requires = ["pax3 >= 0.3.1"]
 setup_requires = []
 tests_require = []
 
@@ -19,5 +19,5 @@ setup(
     tests_require=tests_require,
     packages=find_packages(exclude=["examples", "tests"]),
     extras_require={"test": tests_require},
-    python_requires=">=3.6",
+    python_requires=">=3.7",
 )

--- a/setup.py
+++ b/setup.py
@@ -1,16 +1,18 @@
 from setuptools import find_packages, setup
 
-__version__ = "0.2.2"
+__version__ = "0.2.3rc1"
 url = "https://github.com/ntt123/opax"
 
-install_requires = ["pax3 >= 0.4.0rc2"]
+install_requires = ["pax3 >= 0.4.0rc3"]
 setup_requires = []
 tests_require = []
 
 setup(
     name="opax",
     version=__version__,
-    description="A stateful optimizer library for Jax",
+    description="A stateful optimizer library for JAX",
+    long_description=open("README.md").read(),
+    long_description_content_type="text/markdown",
     author="Thông Nguyễn",
     url=url,
     keywords=["deep-learning", "jax", "pax", "optimizer", "adam", "sgd"],

--- a/tests/test_opax.py
+++ b/tests/test_opax.py
@@ -1,11 +1,13 @@
 import jax
 import jax.numpy as jnp
 import numpy as np
-import opax
 import pax
 import pytest
 
+import opax
 
+
+@pax.pure
 def test_opax_1():
     model = pax.nn.Linear(3, 3)
     learning_rate = 1e-3
@@ -19,6 +21,7 @@ def test_opax_1():
     params = opax.apply_updates(params, updates)
 
 
+@pax.pure
 def test_opax_sgd():
     model = pax.nn.Linear(3, 3)
     opt = opax.chain(
@@ -29,6 +32,7 @@ def test_opax_sgd():
     params = opax.apply_updates(params, updates)
 
 
+@pax.pure
 def test_opax_step_sgd():
     model = pax.nn.Linear(3, 3)
     opt = opax.chain(
@@ -39,6 +43,7 @@ def test_opax_step_sgd():
     params = opax.apply_updates(params, updates)
 
 
+@pax.pure
 def test_opax_adam():
     model = pax.nn.Linear(3, 3)
     opt = opax.adam(1e-3)(model.parameters())
@@ -47,6 +52,7 @@ def test_opax_adam():
     params = opax.apply_updates(params, updates)
 
 
+@pax.pure
 def test_trace():
     x = jnp.array(1.0)
     t = opax.trace(0.9)(x)
@@ -58,6 +64,7 @@ def test_trace():
     np.testing.assert_almost_equal(t.trace, 0.9 * 0.9 + 1.0)
 
 
+@pax.pure
 def test_opax_global_norm():
     model = pax.nn.Linear(3, 3)
     opt = opax.chain(
@@ -86,6 +93,7 @@ def test_opax_global_norm():
 #     assert opt[-1][0].count.item() == 1
 
 
+@pax.pure
 def test_train_1():
     net = pax.nn.Linear(1, 1)
 
@@ -105,6 +113,7 @@ def test_train_1():
         net, opt, _ = update_fn(net, opt, (x, x))
 
 
+@pax.pure
 def test_train_2():
     net = pax.nn.Sequential(
         pax.nn.Linear(1, 2),
@@ -113,7 +122,7 @@ def test_train_2():
 
     def loss_fn(model, inputs):
         loss = jnp.mean(jnp.square(model(inputs[0]) - inputs[1]))
-        model[-1] = pax.nn.Lambda(jax.nn.relu)
+        model = model.set(-1, pax.nn.Lambda(jax.nn.relu))
         return loss, model
 
     def update_fn(model, optimizer, inputs):

--- a/tests/test_opax.py
+++ b/tests/test_opax.py
@@ -127,7 +127,7 @@ def test_train_2():
 
     def update_fn(model, optimizer, inputs):
         (loss, model), grads = jax.value_and_grad(loss_fn, has_aux=True)(model, inputs)
-        model, optimizer = pax.apply_gradients(model, optimizer, grads=grads)
+        model, optimizer = opax.apply_gradients(model, optimizer, grads=grads)
         return model, optimizer, loss
 
     x = jnp.zeros((1, 1))
@@ -149,7 +149,7 @@ def test_train_flatten():
 
     def update_fn(model, optimizer, inputs):
         (loss, model), grads = jax.value_and_grad(loss_fn, has_aux=True)(model, inputs)
-        model, optimizer = pax.apply_gradients(model, optimizer, grads=grads)
+        model, optimizer = opax.apply_gradients(model, optimizer, grads=grads)
         return model, optimizer, loss
 
     x = jnp.zeros((1, 1))

--- a/tests/test_opax.py
+++ b/tests/test_opax.py
@@ -52,19 +52,17 @@ def test_opax_adam():
     params = opax.apply_updates(params, updates)
 
 
-@pax.pure
 def test_trace():
     x = jnp.array(1.0)
     t = opax.trace(0.9)(x)
-    t(x)
+    t, _ = pax.module_and_value(t)(x)
     assert t.trace.item() == 1.0
-    t(x * 0.0)
+    t, _ = pax.module_and_value(t)(x * 0.0)
     np.testing.assert_almost_equal(t.trace, 0.9)
-    t(x)
+    t, _ = pax.module_and_value(t)(x)
     np.testing.assert_almost_equal(t.trace, 0.9 * 0.9 + 1.0)
 
 
-@pax.pure
 def test_opax_global_norm():
     model = pax.nn.Linear(3, 3)
     opt = opax.chain(
@@ -72,7 +70,7 @@ def test_opax_global_norm():
         opax.scale(1e-3),
     )(model.parameters())
     params = model.parameters()
-    updates = opt(params, params)
+    opt, updates = pax.module_and_value(opt)(params, params)
     params = opax.apply_updates(params, updates)
 
     assert opt[0].global_norm >= 0.0

--- a/tests/test_schedule.py
+++ b/tests/test_schedule.py
@@ -1,9 +1,11 @@
 import jax
 import numpy as np
-import opax
 import pax
 
+import opax
 
+
+@pax.pure
 def test_opax_schedule_sgd():
     model = pax.nn.Linear(3, 3)
     scheduler = opax.schedule.exponential_decay(1.0, 10_000)
@@ -12,6 +14,7 @@ def test_opax_schedule_sgd():
     params = opax.apply_updates(params, opt(params))
 
 
+@pax.pure
 def test_opax_schedule_adam():
     model = pax.nn.Linear(3, 3)
     scheduler = opax.schedule.exponential_decay(1.0, 10_000)
@@ -20,6 +23,7 @@ def test_opax_schedule_adam():
     params = opax.apply_updates(params, opt(params, params))
 
 
+@pax.pure
 def test_opax_schedule_adamw():
     model = pax.nn.Linear(3, 3)
     scheduler = opax.schedule.exponential_decay(1.0, 10_000)
@@ -28,6 +32,7 @@ def test_opax_schedule_adamw():
     params = opax.apply_updates(params, opt(params, params))
 
 
+@pax.pure
 def test_opax_schedule_adamw_lr():
     model = pax.nn.Linear(3, 3)
     scheduler = opax.schedule.exponential_decay(1.0, 10_000)
@@ -40,6 +45,7 @@ def test_opax_schedule_adamw_lr():
     )
 
 
+@pax.pure
 def test_opax_schedule_adamw_lr_jaxpr():
     model = pax.nn.Linear(3, 3)
     scheduler = opax.schedule.exponential_decay(1.0, 10_000)

--- a/tests/test_schedule.py
+++ b/tests/test_schedule.py
@@ -32,20 +32,19 @@ def test_opax_schedule_adamw():
     params = opax.apply_updates(params, opt(params, params))
 
 
-@pax.pure
 def test_opax_schedule_adamw_lr():
     model = pax.nn.Linear(3, 3)
     scheduler = opax.schedule.exponential_decay(1.0, 10_000)
     opt = opax.adamw(scheduler)(model.parameters())
     params = model.parameters()
-    params = opax.apply_updates(params, opt(params, params))
+    opt, updates = pax.module_and_value(opt)(params, params)
+    params = opax.apply_updates(params, updates)
     np.testing.assert_almost_equal(
         opt[-1].learning_rate,
         0.9999307,
     )
 
 
-@pax.pure
 def test_opax_schedule_adamw_lr_jaxpr():
     model = pax.nn.Linear(3, 3)
     scheduler = opax.schedule.exponential_decay(1.0, 10_000)
@@ -53,11 +52,13 @@ def test_opax_schedule_adamw_lr_jaxpr():
     params = model.parameters()
 
     def step(opt, a, b):
-        p = opax.apply_updates(params, opt(params, params))
+        opt, updates = pax.module_and_value(opt)(params, params)
+        p = opax.apply_updates(params, updates)
         return p, opt
 
     print(jax.make_jaxpr(step)(opt, params, params))
-    params = opax.apply_updates(params, opt(params, params))
+    opt, updates = pax.module_and_value(opt)(params, params)
+    params = opax.apply_updates(params, updates)
     np.testing.assert_almost_equal(
         opt[-1].learning_rate,
         0.9999307,

--- a/tests/test_schedule.py
+++ b/tests/test_schedule.py
@@ -9,7 +9,7 @@ def test_opax_schedule_sgd():
     scheduler = opax.schedule.exponential_decay(1.0, 10_000)
     opt = opax.sgd(scheduler)(model.parameters())
     params = model.parameters()
-    params = opt.step(params, params)
+    params = opax.apply_updates(params, opt(params))
 
 
 def test_opax_schedule_adam():
@@ -17,7 +17,7 @@ def test_opax_schedule_adam():
     scheduler = opax.schedule.exponential_decay(1.0, 10_000)
     opt = opax.adam(scheduler)(model.parameters())
     params = model.parameters()
-    params = opt.step(params, params)
+    params = opax.apply_updates(params, opt(params, params))
 
 
 def test_opax_schedule_adamw():
@@ -25,7 +25,7 @@ def test_opax_schedule_adamw():
     scheduler = opax.schedule.exponential_decay(1.0, 10_000)
     opt = opax.adamw(scheduler)(model.parameters())
     params = model.parameters()
-    params = opt.step(params, params)
+    params = opax.apply_updates(params, opt(params, params))
 
 
 def test_opax_schedule_adamw_lr():
@@ -33,7 +33,7 @@ def test_opax_schedule_adamw_lr():
     scheduler = opax.schedule.exponential_decay(1.0, 10_000)
     opt = opax.adamw(scheduler)(model.parameters())
     params = model.parameters()
-    params = opt.step(params, params)
+    params = opax.apply_updates(params, opt(params, params))
     np.testing.assert_almost_equal(
         opt[-1].learning_rate,
         0.9999307,
@@ -47,11 +47,11 @@ def test_opax_schedule_adamw_lr_jaxpr():
     params = model.parameters()
 
     def step(opt, a, b):
-        p = opt.step(params, params)
+        p = opax.apply_updates(params, opt(params, params))
         return p, opt
 
     print(jax.make_jaxpr(step)(opt, params, params))
-    params = opt.step(params, params)
+    params = opax.apply_updates(params, opt(params, params))
     np.testing.assert_almost_equal(
         opt[-1].learning_rate,
         0.9999307,


### PR DESCRIPTION
- Use the newest PAX v0.4.0.
- Remove `step` method.
- Add `transform_gradients`, `apply_updates` and `apply_gradients` utility functions.